### PR TITLE
Only load `BridgeComponent` controllers if the Hotwire Native user agent supports the component

### DIFF
--- a/src/bridge_component.js
+++ b/src/bridge_component.js
@@ -1,12 +1,12 @@
 import { Controller } from "@hotwired/stimulus"
 import { BridgeElement } from "./bridge_element"
-import { isHotwireNativeApp } from "./helpers/user_agent"
+import { appSupportsBridgeComponent } from "./helpers/user_agent"
 
 export class BridgeComponent extends Controller {
   static component = ""
 
   static get shouldLoad() {
-    return isHotwireNativeApp
+    return appSupportsBridgeComponent(this.component)
   }
 
   pendingMessageCallbacks = []

--- a/src/helpers/user_agent.js
+++ b/src/helpers/user_agent.js
@@ -1,3 +1,11 @@
 const { userAgent } = window.navigator
 
-export const isHotwireNativeApp = /bridge-components: \[.+\]/.test(userAgent)
+export function appSupportsBridgeComponent(component) {
+    const supportedComponents = userAgent.match(/bridge-components: \[(.*?)\]/)
+
+    if (supportedComponents) {
+      return supportedComponents[1].split(" ").includes(component)
+    } else {
+      return false
+    }
+}

--- a/src/helpers/user_agent.js
+++ b/src/helpers/user_agent.js
@@ -1,11 +1,11 @@
 const { userAgent } = window.navigator
 
 export function appSupportsBridgeComponent(component) {
-    const supportedComponents = userAgent.match(/bridge-components: \[(.*?)\]/)
+  const supportedComponents = userAgent.match(/bridge-components: \[(.*?)\]/)
 
-    if (supportedComponents) {
-      return supportedComponents[1].split(" ").includes(component)
-    } else {
-      return false
-    }
+  if (supportedComponents) {
+    return supportedComponents[1].split(" ").includes(component)
+  } else {
+    return false
+  }
 }


### PR DESCRIPTION
Previously, a `BridgeComponent` controller would always load for any Hotwire Native client app. This has backwards-compatibility concerns depending on how the `BridgeComponent` code was written. `BridgeComponent` controllers should only load for an app that explicitly supports the component via its `User-Agent`.

With this change, `BridgeComponent` controllers will only load on a client app if the component is provided as a supported `bridge-component` in the `User-Agent`.