### PR TITLE
Add better legacy support for alpha Strada clients

### DIFF
--- a/src/bridge_component.js
+++ b/src/bridge_component.js
@@ -69,6 +69,6 @@ export class BridgeComponent extends Controller {
   }
 
   get bridge() {
-    return window.Strada.web
+    return window.HotwireNative.web
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,17 @@ if (!window.HotwireNative) {
   const webBridge = new Bridge()
   window.HotwireNative = { web: webBridge }
 
-  // Legacy client support
-  window.Strada = { web: webBridge }
-  window.webBridge = webBridge
+  addLegacyClientSupport(webBridge)
   
   webBridge.start()
+}
+
+function addLegacyClientSupport(webBridge) {
+  if (!window.Strada) {
+    window.Strada = { web: webBridge }
+  }
+
+  if (!window.webBridge) {
+    window.webBridge = webBridge
+  }
 }


### PR DESCRIPTION
This builds on #7 and provides better support some older native clients that are running early alpha Strada versions. 

This particularly affects early `strada-android` clients that used `Strada` as its `JavascriptInterface` global name, which conflicts with the library's `window.Strada` use.