### PR TITLE
Listen to the `native:restore` event from the native libraries to trigger a manual `connect()` callback

### DIFF
--- a/src/bridge_component.js
+++ b/src/bridge_component.js
@@ -15,11 +15,30 @@ export class BridgeComponent extends Controller {
     this.pendingMessageCallbacks = []
   }
 
-  connect() {}
+  connect() {
+    this.removeRestoreEventListener()
+    this.addRestoreEventListener()
+  }
 
   disconnect() {
     this.removePendingCallbacks()
     this.removePendingMessages()
+    this.removeRestoreEventListener()
+  }
+
+  addRestoreEventListener() {
+    this.restore = this.restore.bind(this)
+    document.addEventListener("native:restore", this.restore)
+  }
+
+  removeRestoreEventListener() {
+    document.removeEventListener("native:restore", this.restore)
+  }
+
+  restore() {
+    // Manually call connect() so the native bridge component has
+    // a chance to restore its view state if it needs to be recreated.
+    this.connect()
   }
 
   get component() {


### PR DESCRIPTION
When a same-page `restore` visit occurs in the native libraries, native apps do not see bridge components connect, even though they may need to recreate their view state.

See details in: https://github.com/hotwired/hotwire-native-android/pull/160